### PR TITLE
Optimise the translateTextNode function

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,18 +342,24 @@
       var mutationCount = 0;
 
       function translateTextNode(node, info) {
-        if(langify.settings.observeCustomContents === false || !node.textContent || node.textContent.trim().length === 0) {
+        if (langify.settings.observeCustomContents === false || Object.keys(customContents_text).length === 0) {
           return;
         }
-        var src = node.textContent.trim().replace(/(\r\n|\n|\r)/gim,"").replace(/\s+/g," ").toLowerCase();
-        if(customContents_text[src] && node.textContent !== customContents_text[src]) {
-          var newContent = node.textContent.replace(node.textContent.trim(), customContents_text[src]);
-          if (newContent != node.textContent) {
+              
+        var textContent = node.textContent || '';
+        var trimmedTextContent = textContent.trim();
+        if (trimmedTextContent.length === 0) {
+          return;
+        }
+
+        var src = trimmedTextContent.replace(/[\r\n]+/gim,"").replace(/\s+/g," ").toLowerCase();
+        if (customContents_text[src] && textContent !== customContents_text[src]) {
+          var newContent = textContent.replace(trimmedTextContent, customContents_text[src]);
+          if (newContent != textContent) {
             if(!node.parentNode.hasAttribute('data-ly-mutation-count') || parseInt(node.parentNode.getAttribute('data-ly-mutation-count')) < langify.settings.maxMutations) {
               var count = node.parentNode.hasAttribute('data-ly-mutation-count') ? parseInt(node.parentNode.getAttribute('data-ly-mutation-count')) : 0;
               node.parentNode.setAttribute('data-ly-mutation-count', count+1);
               node.textContent = newContent;
-
               mutationCount = mutationCount + 1;
               log('REPLACED (TEXT)', {
                   oldValue: src,


### PR DESCRIPTION
The `translateTextNode` is the slowest translation functions, manly because of all of the replacements that are happening to get the correct `src`.

Part of that can be improved in Liquid, there is a code that does something like that:
```liquid
{%- if dst -%}
  customContents[{{ src | downcase | json }}.trim().replace(/(\r\n|\n|\r)/gim,"").replace(/\s+/g," ")] = '{{ dst | replace: "\", "\\\" |  replace: "'", "\\'" }}';
{%- endif -%}
```
but the majority of this logic can be done by Liquid as well I think:
```liquid
{%- if dst -%}
  customContents[{{ src | strip | strip_newlines | downcase | json }}.replace(/\s+/g," ")] = '{{ dst | replace: "\", "\\\" |  replace: "'", "\\'" }}';
{%- endif -%}
```
I don't know if those keys are sometimes used for debugging why the translations are not applied and need to be readable, but simplifying them on both sides would lead to better perf. As you can see, they are quite expensive on a slower device:
<img width="912" alt="image" src="https://github.com/krzksz/langify/assets/829189/a0021246-d0ab-4c99-91de-0e7a9cf3c2ae">
If they have to be readable then getting rid of `.replace(/(\r\n|\n|\r)/gim,"")`/`strip_newlines` and leaving just `.replace(/\s+/g," ")` could still be a good ~30% improvement.